### PR TITLE
Downgrade hexo-action to v1.0.4 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
           pnpm hexo generate
           
       - name: Deploy to GitHub Pages
-        uses: marsen/hexo-action@v1.0.11
+        uses: marsen/hexo-action@v1.0.4
         with:
           deploy_key: ${{ env.DEPLOY_KEY }}
           user_email: ${{ env.USER_EMAIL }}


### PR DESCRIPTION
Reverts the hexo-action GitHub Action from v1.0.11 to v1.0.4 in the deploy workflow. This may address compatibility or stability issues encountered with the newer version.